### PR TITLE
Fix error importing sklearn check scoring

### DIFF
--- a/lofo/flofo_importance.py
+++ b/lofo/flofo_importance.py
@@ -3,7 +3,7 @@ import pandas as pd
 from tqdm import tqdm_notebook
 import multiprocessing
 import warnings
-from sklearn.metrics import check_scoring
+from sklearn.metrics.scorer import check_scoring
 
 
 class FLOFOImportance:


### PR DESCRIPTION
the following line of code was causing an error when trying to import the sklearn.metrics check_scoring function:

from lofo import LOFOImportance, plot_importance

the proposed change corrects this issue. This issue only presents for  sklearn versions < 0.20. However, this updated line works for .20 and below.